### PR TITLE
[update] #3 Make the team name Japanese

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/data
+/data/temp
 /db.sqlite3
+__pycache__/

--- a/data/localize/team_name_list.json
+++ b/data/localize/team_name_list.json
@@ -1,0 +1,22 @@
+{
+    "AC Milan": "ACミラン",
+    "AC Monza": "モンツァ",
+    "ACF Fiorentina": "フィオレンティーナ",
+    "AS Roma": "ローマ",
+    "Atalanta BC": "アタランタ",
+    "Bologna FC 1909": "ボローニャ",
+    "Empoli FC": "エンポリ",
+    "FC Internazionale Milano": "インテル",
+    "Hellas Verona FC": "ヴェローナ",
+    "Juventus FC": "ユヴェントス",
+    "SS Lazio": "ラツィオ",
+    "SSC Napoli": "ナポリ",
+    "Spezia Calcio": "スペツィア",
+    "Torino FC": "トリノ",
+    "UC Sampdoria": "サンプドリア",
+    "US Cremonese": "クレモネーゼ",
+    "US Lecce": "レッツェ",
+    "US Salernitana 1919": "サレルニターナ",
+    "US Sassuolo Calcio": "サッスオーロ",
+    "Udinese Calcio": "ウディネーゼ"
+}

--- a/main/get_info.py
+++ b/main/get_info.py
@@ -6,6 +6,8 @@ import locale
 import pprint
 import requests
 
+from utils import localize
+
 # try scraping  
 def get_match_info_by_scraping():
     target_url = 'https://www.espn.com/soccer/team/fixtures/_/id/103/ita.ac_milan'
@@ -39,8 +41,8 @@ def test_get_info_from_json():
             output_time = utctime.strftime('%Y-%m-%d %H:%M (%a)')
             tmp_dict = {}
             tmp_dict['schedule'] = output_time
-            tmp_dict['home_name'] = match['homeTeam']['name']
-            tmp_dict['away_name'] = match['awayTeam']['name']
+            tmp_dict['home_name'] = localize.get_japanese_team_name(match['homeTeam']['name'])
+            tmp_dict['away_name'] = localize.get_japanese_team_name(match['awayTeam']['name'])
             return_list.append(tmp_dict)
     return return_list
 

--- a/utils/localize.py
+++ b/utils/localize.py
@@ -1,0 +1,7 @@
+import json
+
+def get_japanese_team_name(english_team_name):
+    with open('data/localize/team_name_list.json', mode='r', encoding='utf-8') as f:
+        team_name_dict = json.load(f)
+        japanese_team_name = team_name_dict[english_team_name]
+    return japanese_team_name


### PR DESCRIPTION
close #3 
Changed the notation of the team name from English to Japanese.
The correspondence table was created as team_name_list.json.